### PR TITLE
Minor fixes to get Provided Storage working.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ProvidedReplica.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/ProvidedReplica.java
@@ -73,17 +73,19 @@ public class ProvidedReplica extends ReplicaInfo {
     }
     for (String d : dnDirectories) {
       try {
-        dir = new File(new URI(d));
+        // Strip off [PROVIDED] prefix.
+        StorageLocation storageLocation = StorageLocation.parse(d);
+        dir = storageLocation.getFile();
         break;
-      } catch (URISyntaxException e) {
-        LOG.warn("Invalid URI for data directory: " + d);
+      } catch (IOException e) {
+        LOG.warn("Unable to parse storage location for data directory: " + d);
       }
     }
 
     return FsDatasetUtil.createNullChecksumFile(new File(dir,
         DatanodeUtil.getMetaName(getBlockName(), getGenerationStamp())));
   }
-  
+
   public ProvidedReplica (ProvidedReplica r) {
     super(r);
     this.fileURI = r.fileURI;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/BlockFormatProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/BlockFormatProvider.java
@@ -1,0 +1,67 @@
+package org.apache.hadoop.hdfs.server.namenode;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.protocol.Block;
+import org.apache.hadoop.hdfs.server.blockmanagement.ProvidedStorageMap.BlockProvider;
+import org.apache.hadoop.hdfs.server.common.BlockAlias;
+import org.apache.hadoop.hdfs.server.common.BlockFormat;
+import org.apache.hadoop.hdfs.server.common.TextFileRegionFormat;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BlockFormatProvider extends BlockProvider implements Configurable {
+
+  private Configuration conf;
+  private BlockFormat<? extends BlockAlias> fmt;
+  public static final Logger LOG = LoggerFactory.getLogger(BlockFormatProvider.class);
+
+  @Override
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public void setConf(Configuration conf) {
+    Class<? extends BlockFormat> c =
+      conf.getClass(DFSConfigKeys.IMAGE_WRITER_BLK_CLASS, TextFileRegionFormat.class, BlockFormat.class);
+    fmt = ReflectionUtils.newInstance(c, conf);
+    LOG.info("Loaded BlockFormat class : " + c.getClass().getName());
+    this.conf = conf;
+  }
+
+  @Override
+  public Configuration getConf() {
+    return conf;
+  }
+
+  @Override
+  public Iterator<Block> iterator() {
+    try {
+      final BlockFormat.Reader<? extends BlockAlias> r = fmt.getReader(null);
+      return new Iterator<Block>() {
+
+        final Iterator<? extends BlockAlias> inner = r.iterator();
+
+        @Override
+        public boolean hasNext() {
+          return inner.hasNext();
+        }
+
+        @Override
+        public Block next() {
+          return inner.next().getBlock();
+        }
+
+        @Override
+        public void remove() {
+          throw new UnsupportedOperationException();
+        }
+      };
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read provided blocks", e);
+    }
+  }
+
+}


### PR DESCRIPTION
- Handle `[PROVIDED]` in `dfs.datanode.data.dir`. Without this fix, it seems `dfs.datanode.data.dir` cannot handle paths beginning with `[PROVIDED]` denoting the StorageType.
- Move the `BlockFormatProvider` from fs2img into o.a.h.hdfs.server.namenode so
  it can actually be used to iterate over the blocks. This is required by the
  `dfs.namenode.block.provider.class` option. Otherwise we need to dance around with
  the classpath pointing to the tools directory.
